### PR TITLE
Challenge-5 Dex: Fix path mistake

### DIFF
--- a/packages/react-app/src/components/AddressInput.jsx
+++ b/packages/react-app/src/components/AddressInput.jsx
@@ -1,6 +1,6 @@
 import { CameraOutlined, QrcodeOutlined } from "@ant-design/icons";
 import { Badge, Input, message, Spin } from "antd";
-import { useLookupAddress } from "eth-hooks";
+import { useLookupAddress } from "eth-hooks/dapps/ens";
 import React, { useCallback, useState } from "react";
 import QrReader from "react-qr-reader";
 import Blockie from "./Blockie";


### PR DESCRIPTION
```Attempted import error: 'useLookupAddress' is not exported from 'eth-hooks'.```
Just copied the path from `Address.jsx` component. Not sure why they were different.