### PR TITLE
Update Checkpoint 5 styling + OpenSea Directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ yarn surge
 
 # Checkpoint 5: 📜 Contract Verification
 
-Update the api-key in packages/hardhat/package.json file. You can get your key [here](https://etherscan.io/myapikey).
+Update the `api-key` in `packages/hardhat/package.json` file. You can get your key [here](https://etherscan.io/myapikey).
 
 ![Screen Shot 2021-11-30 at 10 21 01 AM](https://user-images.githubusercontent.com/9419140/144075208-c50b70aa-345f-4e36-81d6-becaa5f74857.png)
 
@@ -186,7 +186,16 @@ Update the api-key in packages/hardhat/package.json file. You can get your key [
 # ⚔️ Side Quests
 
 ## 🐟 Open Sea
-> Add your contract to OpenSea ( create -> submit NFTs -> "or add an existing contract")
+> Add your contract to OpenSea
+> 1. hover over your profile photo in the top right and navigate to `Collections` or go to `https://opensea.io/collections`
+> ![my_collections](https://user-images.githubusercontent.com/46639943/150223014-92a2e32d-d2a2-4fd4-ac3b-bd2d0fcb5840.png)
+> 2. click the vertical elipsis and select `Import an existing smart contract`
+> ![import_contract](https://user-images.githubusercontent.com/46639943/150225448-815a17c1-4ea6-4663-8aff-8f757bebbb54.png)
+> 3. select `Live on a testnet`
+> ![live_on_testnet](https://user-images.githubusercontent.com/46639943/150229334-038100bb-22e0-4240-a293-c2b88adc1219.png)
+> 4. be sure you're on the same network you deployed to and enter your contract address!
+> ![contract_address](https://user-images.githubusercontent.com/46639943/150229361-e50e8c57-3918-450f-8bee-29cf42d65b52.png)
+
 
 (It can take a while before they show up, but here is an example:)
 https://testnets.opensea.io/assets/0xc2839329166d3d004aaedb94dde4173651babccf/1


### PR DESCRIPTION
- added styling to file paths in Checkpoint 5
- updated OpenSea flow for verifying your contract to OpenSea. for me, there is no longer a menu in 'create' - it seems to be reserved for uploading an NFT