### PR TITLE
challenge-0-simple-nft: add NETWORKS object in hardhat.config.js 

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -19,6 +19,30 @@ const { isAddress, getAddress, formatUnits, parseUnits } = utils;
       From here look at deploy/00_deploy_your_contract.js
 */
 
+const NETWORKS = {
+  localhost: "localhost",
+  rinkeby: "rinkeby",
+  kovan: "kovan",
+  mainnet: "mainnet",
+  ropsten: "ropsten",
+  goerli: "goerli",
+  xdai: "xdai",
+  polygon: "polygon",
+  polytest: "polytest",
+  matic: "matic",
+  rinkebyArbitrum: "rinkebyArbitrum",
+  localArbitrum: "localArbitrum",
+  localArbitrumL1: "localArbitrumL1",
+  kovanOptimism: "kovanOptimism",
+  localOptimism: "localOptimism",
+  localOptimismL1: "localOptimismL1",
+  localAvalanche: "localAvalanche",
+  fujiAvalanche: "fujiAvalanche",
+  mainnetAvalanche: "mainnetAvalanche",
+  testnetHarmony: "testnetHarmony",
+  mainnetHarmony: "mainnetHarmony",
+};
+
 // Select the network you want to deploy to here:
 const defaultNetwork = "localhost";
 
@@ -307,20 +331,20 @@ task("fundedwallet", "Create a wallet (pk) link and fund it with deployer?")
       deployerWallet = deployerWallet.connect(ethers.provider);
       console.log(
         "💵 Sending " +
-        amount +
-        " ETH to " +
-        randomWallet.address +
-        " using deployer account"
+          amount +
+          " ETH to " +
+          randomWallet.address +
+          " using deployer account"
       );
       const sendresult = await deployerWallet.sendTransaction(tx);
       console.log("\n" + url + "/pk#" + privateKey + "\n");
     } else {
       console.log(
         "💵 Sending " +
-        amount +
-        " ETH to " +
-        randomWallet.address +
-        " using local node"
+          amount +
+          " ETH to " +
+          randomWallet.address +
+          " using local node"
       );
       console.log("\n" + url + "/pk#" + privateKey + "\n");
       return send(ethers.provider.getSigner(), tx);
@@ -350,8 +374,8 @@ task(
       "0x" + EthUtil.privateToAddress(wallet._privKey).toString("hex");
     console.log(
       "🔐 Account Generated as " +
-      address +
-      " and set as mnemonic in packages/hardhat"
+        address +
+        " and set as mnemonic in packages/hardhat"
     );
     console.log(
       "💬 Use 'yarn run account' to get more information about the deployment account."
@@ -410,12 +434,12 @@ task(
 
     console.log(
       "⛏  Account Mined as " +
-      address +
-      " and set as mnemonic in packages/hardhat"
+        address +
+        " and set as mnemonic in packages/hardhat"
     );
     console.log(
       "📜 This will create the first contract: " +
-      chalk.magenta("0x" + contract_address)
+        chalk.magenta("0x" + contract_address)
     );
     console.log(
       "💬 Use 'yarn run account' to get more information about the deployment account."


### PR DESCRIPTION
- There was no NETWORKS object available in hardhat.config.js file. It took me a while to figure it out and I had to hardcode the value of defaultNetwork variable. 

- Example: `const defaultNetwork = "rinkeby";` instead of `const defaultNetwork = NETWORKS.rinkeby;`. I faced this problem at checkpoint 3 of challenge 0

![image](https://user-images.githubusercontent.com/64621806/151099404-74c6259f-ae12-4ae9-a5de-31e5d5b74f43.png)
