### PR TITLE
Challenge-2 Approve UI Button triggers "Unhandled Rejection (Error)"

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -691,7 +691,7 @@ function App(props) {
                       loading={buying}
                       onClick={async () => {
                         setBuying(true);
-                        await tx(writeContracts.YourToken.approve(readContracts.Vendor.address, tokenSellAmount && ethers.utils.parseEther(tokenSellAmount)));
+                        await tx(writeContracts.YourToken.approve(readContracts.Vendor.address, tokenSellAmount.valid && ethers.utils.parseEther(tokenSellAmount.value)));
                         setBuying(false);
                         let resetAmount = tokenSellAmount
                         setTokenSellAmount("");


### PR DESCRIPTION
When we attempt to use the extra UI to approve/sell tokens by uncommenting that chunk of code (as requested at checkpoint 4 in the speedrun), and as an user you click on the "Approve" button, the following error shows up:

 Unhandled Rejection (Error): value must be a string (argument="value", value= {"value":"1","valid":true}, code=INVALID_ARGUMENT, version=units/5.4.0)

**The Issue**
tokenSellAmount object was not being properly use in App.jsx at line 694

https://github.com/scaffold-eth/scaffold-eth-challenges/blob/08f13e8042145ae30f127570035cbe414939d0d1/packages/react-app/src/App.jsx#L694