### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ yarn deploy
 
 ![networkSelect](https://user-images.githubusercontent.com/12072395/146871168-29b3d87a-7d25-4972-9b3c-0ec8c979171b.PNG)
 
-🔐 Generate a **deployer address** with `yarn generate`
+🔐 Generate a **deployer address** with `yarn run generate`
 
 ![nft7](https://user-images.githubusercontent.com/526558/124387064-7d0a0f00-dcb3-11eb-9d0c-195f93547fb9.png)
 


### PR DESCRIPTION
At step 3, `yarn generate` gave me the error 
```
☢️ WARNING: No mnemonic file created for a deploy account. Try `yarn run generate` and then `yarn run account`.
```
However `yarn run generate` succeeded. Subsequent to calling it once with `run`, I was then able to call `yarn generate` again to create new mnemonics without producing the prior error. Not sure why this is the case. Yarn [documentation says](https://classic.yarnpkg.com/lang/en/docs/cli/run/) scripts are supposed to execute the same with or without `run`.