### PR TITLE
fix(nft-marketplace): import useLookupAddress

### DIFF
--- a/packages/react-app/src/components/AddressInput.jsx
+++ b/packages/react-app/src/components/AddressInput.jsx
@@ -1,6 +1,6 @@
 import { CameraOutlined, QrcodeOutlined } from "@ant-design/icons";
 import { Badge, Input, message, Spin } from "antd";
-import { useLookupAddress } from "eth-hooks";
+import { useLookupAddress } from "eth-hooks/dapps/ens";
 import React, { useCallback, useState } from "react";
 import QrReader from "react-qr-reader";
 import Blockie from "./Blockie";


### PR DESCRIPTION
Fix the following problem:

```
Failed to compile
./src/components/AddressInput.jsx
Attempted import error: 'useLookupAddress' is not exported from 'eth-hooks'.
```