### PR TITLE
Deleted the transfer tokens to vendor since it's already been made by the smart contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ Edit `deploy/01_deploy_vendor.js` to deploy the `Vendor` (uncomment Vendor deplo
 
 > ✏️ So instead, edit `YourToken.sol` to transfer the tokens to the `msg.sender` (deployer) in the **constructor()**.
 
-> ✏️ Then, edit `deploy/01_deploy_vendor.js` to transfer 1000 tokens to `vendor.address`.
-
 ```js
 await yourToken.transfer( vendor.address, ethers.utils.parseEther("1000") );
 ```

--- a/packages/hardhat/deploy/01_deploy_vendor.js
+++ b/packages/hardhat/deploy/01_deploy_vendor.js
@@ -19,17 +19,6 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   //
   // const vendor = await ethers.getContract("Vendor", deployer);
 
-  // Todo: transfer the tokens to the vendor
-  // console.log("\n 🏵  Sending all 1000 tokens to the vendor...\n");
-  //
-  // const transferTransaction = await yourToken.transfer(
-  //   vendor.address,
-  //   ethers.utils.parseEther("1000")
-  // );
-
-  //console.log("\n    ✅ confirming...\n");
-  //await sleep(5000); // wait 5 seconds for transaction to propagate
-
   // ToDo: change address to your frontend address vvvv
   // console.log("\n 🤹  Sending ownership to frontend address...\n")
   // const ownershipTransaction = await vendor.transferOwnership("** YOUR FRONTEND ADDRESS **");


### PR DESCRIPTION
So in the instructions it's said:

- > ✏️ So instead, edit `YourToken.sol` to transfer the tokens to the `msg.sender` (deployer) in the constructor().

- > ✏️ Then, edit `deploy/01_deploy_vendor.js` to transfer 1000 tokens to `vendor.address`.

It's not useful to right the following script (that we have to uncomment):
```
const transferTransaction = await yourToken.transfer(
    vendor.address,
    ethers.utils.parseEther("1000")
);
```
Because we already have written in the smart contract:
```
constructor() ERC20("Gold", "GLD") {
        _mint(msg.sender, 1000e18);
}
```
So according to the [OpenZeppelin's doc about the _mint function](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20-_mint-address-uint256-):

> Creates amount tokens and assigns them to account, increasing the total supply.

I've tested with and without transferring token to vendor in `deploy/01_deploy_vendor.js` and we got the same result: if you check at the balanceOf(vendor's contract address), we got the total supply of tokens (1000 in this example).