### PR TITLE
Add instructions to connect to MM before hitting the mint button on rinkeby

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ You should see the correct network in the frontend (http://localhost:3000):
 
 ![nft10](https://user-images.githubusercontent.com/526558/124387099-9a3edd80-dcb3-11eb-9a57-54a7d370589a.png)
 
+> 🦊 At this moment, you will need to connect the dapp to a browser wallet where you have some ether available to mint tokens. Again, you can use a faucet like [faucet.paradigm.xyz]. Keep in mind that the address you generated in the previous step to deploy the contract will likely be different from the one you have configured in your wallet.
+
 🎫 Ready to mint a batch of NFTs for reals?  Use the `MINT NFT` button.
 
 ![MintNFT2](https://user-images.githubusercontent.com/12072395/145692572-d61c971d-7452-4218-9c66-d675bb78a9dc.PNG)


### PR DESCRIPTION
Without connecting the dapp to a wallet it won't be possible to mint tokens using the dapp.

Take into account the instructions in https://speedrunethereum.com/challenge/simple-nft-example are different from the ones at https://docs.scaffoldeth.io/scaffold-eth/challenges/simple-nft. In the latter it's possible to mint tokens by using:

`yarn mint`

But in the former link, it says "🎫 Ready to mint a batch of NFTs for reals? Use the MINT NFT button.", which is not possible without a browser wallet connected to Rinkeby.

If this is accurate it will probably be nice to add a link with some instructions to connect MM with Rinkeby, right?

Another option could be to ask the user to import in MM the generated account in the previous step which already has some test ether.
