### PR TITLE
dice-game test file update

### DIFF
--- a/packages/hardhat/test/challenge_3.js
+++ b/packages/hardhat/test/challenge_3.js
@@ -107,7 +107,7 @@ describe("🚩 Challenge 3: 🎲 Dice Game", function () {
         expectedRoll.toNumber()
       );
 
-      expect(riggedRoll.riggedRoll()).to.reverted;
+      expect(riggedRoll.riggedRoll()).to.not.emit(diceGame, "Roll");
     });
 
     it("Should withdraw funds", async () => {


### PR DESCRIPTION
Instead of testing if riggedRoll function reverted, test if the Roll event was emitted. The event should not be emitted to pass the test.