### PR TITLE
fix: wrong hardhat path.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-   "solidity.packageDefaultDependenciesDirectory": "packages/hardhat-ts/node_modules",
+   "solidity.packageDefaultDependenciesDirectory": "packages/hardhat/node_modules",
    "solidity-va.test.defaultUnittestTemplate": "hardhat",
    "files.exclude": {
       "**/.git": true,


### PR DESCRIPTION
bug: in vscode, import code like `import "@openzeppelin/contracts/access/Ownable.sol";` will report bug, and can not navigate to the real .sol file. 