### PR TITLE
runs hardhat tests out of the box with WebStorm

### DIFF
--- a/.run/Template Mocha.run.xml
+++ b/.run/Template Mocha.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="mocha-javascript-test-runner">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <mocha-package>$PROJECT_DIR$/packages/hardhat/node_modules/mocha</mocha-package>
+    <working-directory />
+    <pass-parent-env>true</pass-parent-env>
+    <ui />
+    <extra-mocha-options />
+    <test-kind>DIRECTORY</test-kind>
+    <test-directory />
+    <recursive>false</recursive>
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/hardhat/.mocharc.json
+++ b/packages/hardhat/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": "hardhat/register",
+  "timeout": 40000
+}


### PR DESCRIPTION
Runs hardhat tests out of the box with WebStorm.

This also will help with vscode as well as per this issue: https://github.com/NomicFoundation/hardhat/issues/1234
which links to this fix: https://hardhat.org/hardhat-runner/docs/advanced/vscode-tests

Here are some screenshots of how you would initially click on the mocha option instead of the jest one, and the tests being run:
<img width="1680" alt="Screen Shot 2022-10-16 at 4 33 56 AM" src="https://user-images.githubusercontent.com/13500774/196028531-5de8e3dd-db1b-402c-a78e-914ff6291fa7.png">

<img width="1792" alt="Screen Shot 2022-10-16 at 4 35 43 AM" src="https://user-images.githubusercontent.com/13500774/196028529-606e1418-859e-4ef9-882e-d3a25047fc0a.png">

