### PR TITLE
Challenge 4 dex remove safemath

### DIFF
--- a/packages/hardhat/contracts/DEX.sol
+++ b/packages/hardhat/contracts/DEX.sol
@@ -3,7 +3,6 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /**
  * @title DEX Template
@@ -15,7 +14,6 @@ import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 contract DEX {
     /* ========== GLOBAL VARIABLES ========== */
 
-    using SafeMath for uint256; //outlines use of SafeMath for uint256 variables
     IERC20 token; //instantiates the imported contract
 
     /* ========== EVENTS ========== */


### PR DESCRIPTION
From Solidity Docs change: https://docs.soliditylang.org/en/v0.8.9/080-breaking-changes.html

Implemented code change suggestion: "If you use SafeMath or a similar library, change x.add(y) to x + y, x.mul(y) to x * y etc."

Personally tested the code before and after the change. It also passes all 17 tests.